### PR TITLE
POST /initializeのinit.shを削除

### DIFF
--- a/webapp/ruby/app.sh
+++ b/webapp/ruby/app.sh
@@ -1,0 +1,1 @@
+/sql/init.sh && rackup --host 0.0.0.0 --port 8000 -s WEBrick

--- a/webapp/ruby/lib/isucari/web.rb
+++ b/webapp/ruby/lib/isucari/web.rb
@@ -252,10 +252,6 @@ module Isucari
 
     # postInitialize
     post '/initialize' do
-      unless system "#{settings.root}/../sql/init.sh"
-        halt_with_error 500, 'exec init.sh error'
-      end
-
       ['payment_service_url', 'shipment_service_url'].each do |name|
         value = body_params[name].gsub('localhost', 'host.docker.internal')
         db.xquery('INSERT INTO `configs` (name, val) VALUES (?, ?) ON DUPLICATE KEY UPDATE `val` = VALUES(`val`)', name, value)


### PR DESCRIPTION
動作要件

```
docker-compose exec app bash
./app.sh
```

`POST /initialize`がnewrelicのメトリクスを占めていて見辛い